### PR TITLE
Fit 22: optimize workout tracker components

### DIFF
--- a/src/features/workout-tracker/components/WorkoutTrackerExercise/WorkoutTrackerExercise.tsx
+++ b/src/features/workout-tracker/components/WorkoutTrackerExercise/WorkoutTrackerExercise.tsx
@@ -9,8 +9,8 @@ import {
     type ExerciseSetsActions,
 } from '../../reducers/ExerciseSetsReducer';
 import { ExercisesActionsTypes, type ExercisesActions } from '../../reducers/ExercisesReducer';
+import WorkoutTrackerSet from '../WorkoutTrackerSet/WorkoutTrackerSet';
 import { ExerciseContainer, FlexView, Icon, Row } from './WorkoutTrackerExerciseStyles';
-import WorkoutTrackerSet from './WorkoutTrackerSet';
 
 interface ExerciseProps {
     exercise: Exercise;

--- a/src/features/workout-tracker/components/WorkoutTrackerExercise/WorkoutTrackerExerciseStyles.ts
+++ b/src/features/workout-tracker/components/WorkoutTrackerExercise/WorkoutTrackerExerciseStyles.ts
@@ -1,13 +1,9 @@
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 
 import Ionicons from '@expo/vector-icons/Ionicons';
 import styled from 'styled-components';
 
 export const ExerciseContainer = styled(View)``;
-
-export const ExerciseSetContainer = styled(View)`
-    background-color: ${(props) => props.theme.colors.white};
-`;
 
 export const Row = styled(View)`
     flex-direction: row;
@@ -22,18 +18,4 @@ export const Icon = styled(Ionicons)`
 export const FlexView = styled(View)<{ flex: number }>`
     flex: ${(props) => props.flex};
     align-items: center;
-`;
-
-export const DeleteSetContainer = styled(View)`
-    background-color: ${(props) => props.theme.colors.error};
-    justify-content: center;
-    align-items: flex-end;
-    padding-right: ${(props) => props.theme.spacing.xxs};
-    flex: 1;
-`;
-
-export const DeleteSetText = styled(Text)`
-    font-size: ${(props) => props.theme.fontSize.body}px;
-    font-family: ${(props) => props.theme.fonts.regular};
-    color: ${(props) => props.theme.fontColors.white};
 `;

--- a/src/features/workout-tracker/components/WorkoutTrackerSet/WorkoutTrackerSet.tsx
+++ b/src/features/workout-tracker/components/WorkoutTrackerSet/WorkoutTrackerSet.tsx
@@ -9,12 +9,7 @@ import {
     ExerciseSetsActionsTypes,
     type ExerciseSetsActions,
 } from '../../reducers/ExerciseSetsReducer';
-import {
-    DeleteSetContainer,
-    ExerciseSetContainer,
-    FlexView,
-    Row,
-} from './WorkoutTrackerExerciseStyles';
+import { DeleteSetContainer, ExerciseSetContainer, FlexView, Row } from './WorkoutTrackerSetStyles';
 
 interface Props {
     set: ExerciseSet;

--- a/src/features/workout-tracker/components/WorkoutTrackerSet/WorkoutTrackerSetStyles.ts
+++ b/src/features/workout-tracker/components/WorkoutTrackerSet/WorkoutTrackerSetStyles.ts
@@ -1,0 +1,32 @@
+import { Text, View } from 'react-native';
+
+import styled from 'styled-components';
+
+export const ExerciseSetContainer = styled(View)`
+    background-color: ${(props) => props.theme.colors.white};
+`;
+
+export const Row = styled(View)`
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+`;
+
+export const FlexView = styled(View)<{ flex: number }>`
+    flex: ${(props) => props.flex};
+    align-items: center;
+`;
+
+export const DeleteSetContainer = styled(View)`
+    background-color: ${(props) => props.theme.colors.error};
+    justify-content: center;
+    align-items: flex-end;
+    padding-right: ${(props) => props.theme.spacing.xxs};
+    flex: 1;
+`;
+
+export const DeleteSetText = styled(Text)`
+    font-size: ${(props) => props.theme.fontSize.body}px;
+    font-family: ${(props) => props.theme.fonts.regular};
+    color: ${(props) => props.theme.fontColors.white};
+`;


### PR DESCRIPTION
# Description

- Make WorkoutTrackerExercise and WorkoutTrackerSet into memoized components so they only re-rendered if their props changed
- Makes the form more optimized so all exercises aren't re-rendering if an exercise is added and all sets aren't re-rendering if a set is added
- Also Moved WorkoutTrackerSet into its own folder with a styles file to make code more clean

Resolves FIT-22

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

